### PR TITLE
feat: notify auction winner via email

### DIFF
--- a/apps/api/src/auctions/auctions.module.ts
+++ b/apps/api/src/auctions/auctions.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AuctionsService } from './auctions.service';
 import { AuctionsController } from './auctions.controller';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
+  imports: [NotificationsModule],
   providers: [AuctionsService],
   controllers: [AuctionsController],
   exports: [AuctionsService],

--- a/apps/api/src/auctions/auctions.service.ts
+++ b/apps/api/src/auctions/auctions.service.ts
@@ -1,11 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaClient, AuctionStatus } from '@prisma/client';
 import { Cron } from '@nestjs/schedule';
+import { NotificationsService } from '../notifications/notifications.service';
 
 const prisma = new PrismaClient();
 
 @Injectable()
 export class AuctionsService {
+  constructor(private readonly notifications: NotificationsService) {}
   findAll() {
     return prisma.auction.findMany({
       where: { status: AuctionStatus.ACTIVE },
@@ -43,11 +45,37 @@ export class AuctionsService {
     return prisma.auction.update({ where: { id }, data });
   }
 
-  close(id: number) {
-    return prisma.auction.update({
-      where: { id },
-      data: { status: AuctionStatus.ENDED },
+  async close(id: number) {
+    const [updated] = await prisma.$transaction([
+      prisma.auction.update({
+        where: { id },
+        data: { status: AuctionStatus.ENDED },
+      }),
+      prisma.auditLog.create({
+        data: {
+          action: 'AUCTION_ENDED',
+          entityType: 'Auction',
+          entityId: id,
+          details: {},
+          ip: '',
+          ua: '',
+        },
+      }),
+    ]);
+
+    const winner = await prisma.bid.findFirst({
+      where: { auctionId: id },
+      orderBy: { amount: 'desc' },
+      include: { user: true },
     });
+    if (winner?.user?.email) {
+      await this.notifications.sendWinnerEmail(
+        winner.user.email,
+        updated.title,
+        winner.amount,
+      );
+    }
+    return updated;
   }
 
   @Cron('*/30 * * * * *')
@@ -57,7 +85,7 @@ export class AuctionsService {
       where: { status: AuctionStatus.ACTIVE, endAt: { lte: now } },
     });
     for (const auction of auctions) {
-      await prisma.$transaction([
+      const [updated] = await prisma.$transaction([
         prisma.auction.update({
           where: { id: auction.id },
           data: { status: AuctionStatus.ENDED },
@@ -73,6 +101,19 @@ export class AuctionsService {
           },
         }),
       ]);
+
+      const winner = await prisma.bid.findFirst({
+        where: { auctionId: auction.id },
+        orderBy: { amount: 'desc' },
+        include: { user: true },
+      });
+      if (winner?.user?.email) {
+        await this.notifications.sendWinnerEmail(
+          winner.user.email,
+          updated.title,
+          winner.amount,
+        );
+      }
     }
   }
 }

--- a/apps/api/src/notifications/notifications.module.ts
+++ b/apps/api/src/notifications/notifications.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { NotificationsService } from './notifications.service';
+
+@Module({
+  providers: [NotificationsService],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -1,0 +1,35 @@
+import { Injectable, Logger } from '@nestjs/common';
+import nodemailer from 'nodemailer';
+
+@Injectable()
+export class NotificationsService {
+  private readonly logger = new Logger(NotificationsService.name);
+  private readonly transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT) || 587,
+    secure: false,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+
+  async sendWinnerEmail(to: string, auctionTitle: string, amount: number) {
+    if (!to) {
+      this.logger.warn('Missing recipient for winner email');
+      return;
+    }
+    const from = process.env.SMTP_FROM || process.env.SMTP_USER;
+    const message = {
+      from,
+      to,
+      subject: `Wygrana aukcja: ${auctionTitle}`,
+      text: `Gratulacje! Wygrałeś aukcję \"${auctionTitle}\" z ofertą ${amount}.`,
+    };
+    try {
+      await this.transporter.sendMail(message);
+    } catch (err) {
+      this.logger.error('Failed to send winner email', err);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add NotificationsService using nodemailer to send winner emails
- notify winning bidder when auctions close automatically or manually

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689689a3a5708325ac466b81f865e845